### PR TITLE
Update setup.ssjs

### DIFF
--- a/setup/setup.ssjs
+++ b/setup/setup.ssjs
@@ -253,7 +253,7 @@
                 { "Name": "date", "FieldType": "Date", "IsRequired": true },
                 { "Name": "timestamp", "FieldType": "Text", "MaxLength": 25, "IsRequired": true, "IsPrimaryKey": true },
                 { "Name": "id", "FieldType": "Text", "MaxLength": 255, "IsRequired": true, "IsPrimaryKey": true },
-                { "Name": "message", "FieldType": "Text", "MaxLength": 4000, "IsRequired": true, "IsPrimaryKey": true },
+                { "Name": "message", "FieldType": "Text", "MaxLength": 4000, "IsRequired": true },
                 { "Name": "level", "FieldType": "Text", "MaxLength": 50, "IsRequired": true, "IsPrimaryKey": true },
                 { "Name": "category", "FieldType": "Text", "MaxLength": 254, "IsRequired": true, "IsPrimaryKey": true },
                 { "Name": "subscriberKey", "FieldType": "Text", "MaxLength": 254, "IsRequired": true, "IsPrimaryKey": true }


### PR DESCRIPTION
@shdinx
I was trying to reach you to discuss this change first, but it is necessary to just make the change and propose it.

Long story, but more or less, using a text field of length 4000 as part of a Primary Key violates PK maximum lengths allowed. There are more issues as well, which I can explain if you wish to discuss it further. Reach out to me: jpayne@salesforce.com

More or less this automatic declaration of the long text field as part of a PK is causing issues and so going forward anyone using this cannot have those fields as part of PK. For cleanup, I need to now go through and drop the PKs on all the Data Extensions created from this script and then rebuild them, so they do not include "message".

Thank you. Reach out to discuss!